### PR TITLE
Add Windows Installer Setup for Mina Al Arabi Salon Manager

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ build_windows.bat
 ```
 بعد الانتهاء ستجد الملف التنفيذي هنا:
 ```
-dist\MinaAlArabiSalonManager\MinaAlArabiSalonManager.exe
+dist\\MinaAlArabiSalonManager\\MinaAlArabiSalonManager.exe
 ```
 
 بديل (باستخدام spec مباشرة):
@@ -49,6 +49,34 @@ pyinstaller MinaAlArabiSalonManager.spec
 ملاحظات:
 - إذا ظهرت مشكلة في PySide6 على ويندوز، ثبّت Microsoft Visual C++ Redistributable (2015-2022).
 - يمكنك نقل مجلد dist بالكامل لأي جهاز وتشغيل البرنامج بدون تثبيت بايثون.
+
+## إنشاء مُثبت لويندوز (Installer)
+
+لإنشاء ملف مُثبت .exe يسهل على المستخدمين تثبيت البرنامج على ويندوز:
+
+1) أولاً أنشئ الملف التنفيذي عبر:
+```
+build_windows.bat
+```
+
+2) ثبّت Inno Setup (مجاني) من:
+```
+https://jrsoftware.org/isdl.php
+```
+وتأكد أن الأمر `iscc` يعمل داخل الـ PATH (عادةً يكون في:
+`C:\Program Files (x86)\Inno Setup 6\iscc.exe`).
+
+3) ابنِ المُثبت عبر ملف الباتش:
+```
+build_installer_windows.bat
+```
+
+بعد الانتهاء ستجد المُثبت هنا:
+```
+installer\\windows\\output\\MinaAlArabiSalonManagerSetup.exe
+```
+
+يمكنك توزيع هذا الملف على أي جهاز ويندوز، وسيقوم بإنشاء اختصار وتشغيل التطبيق مباشرةً.
 
 ## الواجهات
 

--- a/build_installer_windows.bat
+++ b/build_installer_windows.bat
@@ -1,0 +1,37 @@
+@echo off
+setlocal
+
+REM Build Windows installer (Inno Setup) for "Mina Al Arabi Salon Manager"
+
+echo.
+echo [1/3] Checking PyInstaller build output...
+if not exist "dist\MinaAlArabiSalonManager\MinaAlArabiSalonManager.exe" (
+  echo   ERROR: Executable not found.
+  echo   Please run build_windows.bat first to generate the EXE.
+  exit /b 1
+)
+
+echo.
+echo [2/3] Checking Inno Setup compiler (iscc) availability...
+where iscc >nul 2>&1
+if errorlevel 1 (
+  echo   ERROR: Inno Setup compiler (iscc) not found in PATH.
+  echo   Install Inno Setup from: https://jrsoftware.org/isdl.php
+  echo   Then ensure iscc.exe is in PATH (usually "C:\Program Files (x86)\Inno Setup 6\iscc.exe").
+  exit /b 1
+)
+
+echo.
+echo [3/3] Building Installer with Inno Setup...
+iscc "installer\windows\MinaAlArabiSalonManager.iss"
+if errorlevel 1 (
+  echo   ERROR: Installer build failed.
+  exit /b 1
+)
+
+echo.
+echo Installer build finished.
+echo You can find the setup here:
+echo   installer\windows\output\MinaAlArabiSalonManagerSetup.exe
+
+endlocal

--- a/installer/windows/MinaAlArabiSalonManager.iss
+++ b/installer/windows/MinaAlArabiSalonManager.iss
@@ -1,0 +1,39 @@
+; Inno Setup Script for "Mina Al Arabi Salon Manager"
+; Requires Inno Setup (https://jrsoftware.org/isinfo.php) installed and `iscc` available in PATH.
+
+[Setup]
+AppName=Mina Al Arabi Salon Manager
+AppVersion=1.0.0
+AppPublisher=Mina Al Arabi
+DefaultDirName={pf}\MinaAlArabiSalonManager
+DefaultGroupName=Mina Al Arabi Salon Manager
+OutputDir=installer\windows\output
+OutputBaseFilename=MinaAlArabiSalonManagerSetup
+Compression=lzma
+SolidCompression=yes
+DisableDirPage=no
+DisableProgramGroupPage=no
+ArchitecturesInstallIn64BitMode=x64
+UsePreviousLanguage=no
+
+[Languages]
+Name: "arabic"; MessagesFile: "compiler:Languages\Arabic.isl"
+Name: "english"; MessagesFile: "compiler:Default.isl"
+
+[Files]
+; Include all files created by PyInstaller
+Source: "dist\MinaAlArabiSalonManager\*"; DestDir: "{app}"; Flags: ignoreversion recursesubdirs createallsubdirs
+
+[Tasks]
+Name: "desktopicon"; Description: "إنشاء اختصار على سطح المكتب"; GroupDescription: "خيارات إضافية:"; Flags: unchecked
+
+[Icons]
+Name: "{group}\Mina Al Arabi Salon Manager"; Filename: "{app}\MinaAlArabiSalonManager.exe"
+Name: "{commondesktop}\Mina Al Arabi Salon Manager"; Filename: "{app}\MinaAlArabiSalonManager.exe"; Tasks: desktopicon
+
+[Run]
+Filename: "{app}\MinaAlArabiSalonManager.exe"; Description: "تشغيل التطبيق"; Flags: nowait postinstall skipifsilent
+
+[UninstallDelete]
+; Optionally clean generated data folders on uninstall (comment out if you want to keep user data)
+Type: filesandordirs; Name: "{app}\data"

--- a/installer/windows/MinaAlArabiSalonManager.iss
+++ b/installer/windows/MinaAlArabiSalonManager.iss
@@ -2,11 +2,11 @@
 ; Requires Inno Setup (https://jrsoftware.org/isinfo.php) installed and `iscc` available in PATH.
 
 [Setup]
-AppName=Mina Al Arabi Salon Manager
+AppName=مدير صالون مينا العربي
 AppVersion=1.0.0
 AppPublisher=Mina Al Arabi
 DefaultDirName={pf}\MinaAlArabiSalonManager
-DefaultGroupName=Mina Al Arabi Salon Manager
+DefaultGroupName=مدير صالون مينا العربي
 OutputDir=installer\windows\output
 OutputBaseFilename=MinaAlArabiSalonManagerSetup
 Compression=lzma
@@ -24,12 +24,10 @@ Name: "english"; MessagesFile: "compiler:Default.isl"
 ; Include all files created by PyInstaller
 Source: "dist\MinaAlArabiSalonManager\*"; DestDir: "{app}"; Flags: ignoreversion recursesubdirs createallsubdirs
 
-[Tasks]
-Name: "desktopicon"; Description: "إنشاء اختصار على سطح المكتب"; GroupDescription: "خيارات إضافية:"; Flags: unchecked
-
 [Icons]
-Name: "{group}\Mina Al Arabi Salon Manager"; Filename: "{app}\MinaAlArabiSalonManager.exe"
-Name: "{commondesktop}\Mina Al Arabi Salon Manager"; Filename: "{app}\MinaAlArabiSalonManager.exe"; Tasks: desktopicon
+; Always create Start Menu and Desktop shortcuts with app name
+Name: "{group}\مدير صالون مينا العربي"; Filename: "{app}\MinaAlArabiSalonManager.exe"
+Name: "{commondesktop}\مدير صالون مينا العربي"; Filename: "{app}\MinaAlArabiSalonManager.exe"
 
 [Run]
 Filename: "{app}\MinaAlArabiSalonManager.exe"; Description: "تشغيل التطبيق"; Flags: nowait postinstall skipifsilent


### PR DESCRIPTION
This pull request adds a Windows installer for the Mina Al Arabi Salon Manager application. The README has been updated to include detailed instructions on creating an installer using Inno Setup. Additionally, a new batch file (`build_installer_windows.bat`) has been added that checks prerequisites and builds the installer, as well as an Inno Setup script (`MinaAlArabiSalonManager.iss`) which defines the installation parameters. This enhancements allows users to easily install the application on Windows without needing Python.

---

> This pull request was co-created with Cosine Genie

Original Task: [mina-barbershop/zvjo5my7emjp](https://cosine.sh/cik7qr0yofm5/mina-barbershop/task/zvjo5my7emjp)
Author: Ahmed Tarek
